### PR TITLE
feat: 마이페이지(기본 내정보표시/수정버튼으로 내정보 변경) 기능 구현

### DIFF
--- a/coffee-front/src/app/me/page.tsx
+++ b/coffee-front/src/app/me/page.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const API = process.env.NEXT_PUBLIC_API_BASE ?? "/api";
+
+type CustomerDto = {
+  email: string;
+  username: string;
+  address: string;
+  postalCode: number;
+};
+
+export default function MyPage() {
+  const [customer, setCustomer] = useState<CustomerDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [editMode, setEditMode] = useState(false);
+  const [form, setForm] = useState<CustomerDto | null>(null);
+  const [password, setPassword] = useState("");
+
+  // GET /customer/me
+  const load = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`${API}/customer/me`, {
+        method: "GET",
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error(`(${res.status}) 조회 실패`);
+      const data = await res.json();
+      const dto: CustomerDto = data.data.customerDto;
+      setCustomer(dto);
+      setForm(dto);
+    } catch (err: any) {
+      setError(err.message ?? "내 정보 불러오기 실패");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // PUT /customer/me
+  const save = async () => {
+    if (!form) return;
+    try {
+      const res = await fetch(`${API}/customer/me`, {
+        method: "PUT",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...form,
+          password,
+        }),
+      });
+      // 본문 한 번만 읽기
+    const data = await res.json().catch(() => null);
+
+    // HTTP 실패 또는 비즈니스 코드 실패 모두 처리
+    if (!res.ok || data?.resultCode !== "200") {
+      if (data?.msg?.includes("비밀번호")) {
+        throw new Error("비밀번호가 일치하지 않습니다");
+      }
+      throw new Error(data?.msg || `(${res.status}) 요청 실패`);
+    }
+      await load();
+      setEditMode(false);
+      alert("수정되었습니다.");
+    } catch (err: any) {
+      alert(err.message || "수정 실패");
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div className="text-red-500">{error}</div>;
+  if (!customer || !form) return <div>데이터 없음</div>;
+
+  return (
+    <div className="max-w-md mx-auto p-6 bg-white text-black rounded-xl shadow-md">
+      <h1 className="text-2xl font-semibold mb-4">마이페이지</h1>
+
+      {!editMode ? (
+        <>
+          <p><strong>이메일:</strong> {customer.email}</p>
+          <p><strong>이름:</strong> {customer.username}</p>
+          <p><strong>주소:</strong> {customer.address}</p>
+          <p><strong>우편번호:</strong> {customer.postalCode}</p>
+          <button
+            className="mt-4 px-4 py-2 bg-gray-800 text-white rounded"
+            onClick={() => setEditMode(true)}
+          >
+            수정
+          </button>
+        </>
+      ) : (
+        <div className="space-y-3">
+          <div>
+            <label className="block text-sm font-medium">이메일 (변경 불가)</label>
+            <input
+              type="email"
+              value={form.email}
+              readOnly
+              className="w-full border px-3 py-2 rounded bg-gray-100 text-gray-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">비밀번호 (확인용)</label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="w-full border px-3 py-2 rounded"
+              placeholder="현재 비밀번호"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">이름</label>
+            <input
+              type="text"
+              value={form.username}
+              onChange={(e) => setForm({ ...form, username: e.target.value })}
+              className="w-full border px-3 py-2 rounded"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">주소</label>
+            <input
+              type="text"
+              value={form.address}
+              onChange={(e) => setForm({ ...form, address: e.target.value })}
+              className="w-full border px-3 py-2 rounded"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">우편번호</label>
+            <input
+              type="text"
+              value={form.postalCode}
+              onChange={(e) =>
+                setForm({ ...form, postalCode: Number(e.target.value) })
+              }
+              className="w-full border px-3 py-2 rounded"
+            />
+          </div>
+          <div className="flex gap-2">
+            <button
+              className="px-4 py-2 bg-blue-600 text-white rounded"
+              onClick={save}
+            >
+              저장
+            </button>
+            <button
+              className="px-4 py-2 bg-gray-400 text-white rounded"
+              onClick={() => setEditMode(false)}
+            >
+              취소
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
마이페이지
- 쿠키기반 로그인중인 회원 -> 내정보 조회 기능 추가
- 해당 페이지에서 수정버튼을 누르면 (이메일(read only), 비밀번호(확인용), 사용자이름, 주소, 우편번호)를 입력받는 폼으로 바뀌고
- 여기서 비밀번호 일치하고, 나머지 필드도 입력형식에 맞게 제출되면, 사용자 정보가 수정됩니다.